### PR TITLE
added urn for netcam so it finds NetCam camera

### DIFF
--- a/discover.go
+++ b/discover.go
@@ -30,6 +30,7 @@ func (self *Wemo) DiscoverAll(timeout time.Duration) ([]*Device, error) {
 		"urn:Belkin:device:controllee:1",
 		"urn:Belkin:device:light:1",
 		"urn:Belkin:device:sensor:1",
+		"urn:Belkin:device:netcam:1",
 	}
 
 	var all []*Device
@@ -56,6 +57,5 @@ func (self *Wemo) Discover(urn string, timeout time.Duration) ([]*Device, error)
 			devices = append(devices, &Device{Host: host})
 		}
 	}
-
 	return devices, nil
 }


### PR DESCRIPTION
I have a Belkin NetCam HD+ that this library was not finding. Adding the urn with "nectam" in it means that it finds it now.
Thanks.
