### PR TITLE
Changed imports to work after code.google.com shutdown.

### DIFF
--- a/device.go
+++ b/device.go
@@ -14,7 +14,7 @@
 package wemo
 
 import (
-	"code.google.com/p/go.net/context"
+	"golang.org/x/net/context"
 	"encoding/xml"
 	"errors"
 	"fmt"

--- a/wemo.go
+++ b/wemo.go
@@ -14,7 +14,7 @@
 package wemo
 
 import (
-	"code.google.com/p/go.net/context"
+	"golang.org/x/net/context"
 	"time"
 )
 

--- a/wemo/discover.go
+++ b/wemo/discover.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"code.google.com/p/go.net/context"
+	"golang.org/x/net/context"
 	"fmt"
 	"github.com/codegangsta/cli"
 	"github.com/savaki/go.wemo"


### PR DESCRIPTION
With code.google.com now shutdown the go.net imports were broken. Fixed to point to the golang.org source. I tested with my local Wemo wall switch and was able to compile and toggle the light.
