### PR TITLE
Updates go.net/context references to /x/net/context

### DIFF
--- a/device.go
+++ b/device.go
@@ -14,16 +14,17 @@
 package wemo
 
 import (
-	"code.google.com/p/go.net/context"
 	"encoding/xml"
 	"errors"
 	"fmt"
-	"github.com/savaki/httpctx"
 	"io/ioutil"
 	"log"
 	"net/http"
 	"regexp"
 	"strconv"
+
+	"github.com/savaki/httpctx"
+	"golang.org/x/net/context"
 )
 
 type Device struct {

--- a/wemo.go
+++ b/wemo.go
@@ -14,7 +14,7 @@
 package wemo
 
 import (
-	"code.google.com/p/go.net/context"
+	"golang.org/x/net/context"
 	"time"
 )
 

--- a/wemo/discover.go
+++ b/wemo/discover.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"code.google.com/p/go.net/context"
+	"golang.org/x/net/context"
 	"fmt"
 	"github.com/codegangsta/cli"
 	"github.com/savaki/go.wemo"


### PR DESCRIPTION
Fixes references to the context library so the library can be pull (since code.google.com is no more)
